### PR TITLE
Fix client secret verification pattern

### DIFF
--- a/InHouseOidc.Certify.Provider/Program.cs
+++ b/InHouseOidc.Certify.Provider/Program.cs
@@ -51,6 +51,7 @@ var clientOptions = new PageClientOptions
     AccessDeniedPath = "/AccessDenied",
     ClientId = "providercertify",
     GetClaimsFromUserInfoEndpoint = true,
+    IssueLocalAuthenticationCookie = false,
     OidcProviderAddress = providerAddress,
     Scope = "openid address email phone profile",
     UniqueClaimMappings = new() { { "address", "address" }, { "phone_number", "phone_number" } },

--- a/InHouseOidc.Example.Provider/ClientStore.cs
+++ b/InHouseOidc.Example.Provider/ClientStore.cs
@@ -7,102 +7,114 @@ namespace InHouseOidc.Example.Provider
 {
     public class ClientStore : IClientStore
     {
-        private readonly Dictionary<string, OidcClient> clients =
+        private readonly Dictionary<string, (OidcClient OidcClient, string? ClientSecret)> clients =
             new()
             {
                 {
                     "clientcredentialsexample",
-                    new OidcClient
-                    {
-                        AccessTokenExpiry = TimeSpan.FromMinutes(15),
-                        ClientId = "clientcredentialsexample",
-                        ClientSecret = "topsecret",
-                        GrantTypes = new() { GrantType.ClientCredentials },
-                        Scopes = new() { "exampleapiscope" },
-                    }
+                    (
+                        new OidcClient
+                        {
+                            AccessTokenExpiry = TimeSpan.FromMinutes(15),
+                            ClientId = "clientcredentialsexample",
+                            ClientSecretRequired = true,
+                            GrantTypes = new() { GrantType.ClientCredentials },
+                            Scopes = new() { "exampleapiscope" },
+                        },
+                        "topsecret"
+                    )
                 },
                 {
                     "mvcexample",
-                    new OidcClient
-                    {
-                        AccessTokenExpiry = TimeSpan.FromMinutes(15),
-                        ClientId = "mvcexample",
-                        GrantTypes = new() { GrantType.AuthorizationCode, GrantType.RefreshToken },
-                        IdentityTokenExpiry = TimeSpan.FromMinutes(60),
-                        RedirectUris = new()
+                    (
+                        new OidcClient
                         {
-                            "http://localhost:5103",
-                            "http://localhost:5103/connect/authorize/callback",
+                            AccessTokenExpiry = TimeSpan.FromMinutes(15),
+                            ClientId = "mvcexample",
+                            GrantTypes = new() { GrantType.AuthorizationCode, GrantType.RefreshToken },
+                            IdentityTokenExpiry = TimeSpan.FromMinutes(60),
+                            RedirectUris = new()
+                            {
+                                "http://localhost:5103",
+                                "http://localhost:5103/connect/authorize/callback",
+                            },
+                            RedirectUrisPostLogout = new()
+                            {
+                                "http://localhost:5103",
+                                "http://localhost:5103/signout-callback-oidc",
+                            },
+                            Scopes = new()
+                            {
+                                "openid",
+                                "offline_access",
+                                "email",
+                                "phone",
+                                "profile",
+                                "role",
+                                "exampleapiscope",
+                                "exampleproviderapiscope",
+                            },
                         },
-                        RedirectUrisPostLogout = new()
-                        {
-                            "http://localhost:5103",
-                            "http://localhost:5103/signout-callback-oidc",
-                        },
-                        Scopes = new()
-                        {
-                            "openid",
-                            "offline_access",
-                            "email",
-                            "phone",
-                            "profile",
-                            "role",
-                            "exampleapiscope",
-                            "exampleproviderapiscope",
-                        },
-                    }
+                        null
+                    )
                 },
                 {
                     "providerexample",
-                    new OidcClient
-                    {
-                        AccessTokenExpiry = TimeSpan.FromMinutes(15),
-                        ClientId = "providerexample",
-                        GrantTypes = new() { GrantType.AuthorizationCode },
-                        IdentityTokenExpiry = TimeSpan.FromMinutes(60),
-                        RedirectUris = new()
+                    (
+                        new OidcClient
                         {
-                            "http://localhost:5100",
-                            "http://localhost:5100/connect/authorize/callback",
+                            AccessTokenExpiry = TimeSpan.FromMinutes(15),
+                            ClientId = "providerexample",
+                            GrantTypes = new() { GrantType.AuthorizationCode },
+                            IdentityTokenExpiry = TimeSpan.FromMinutes(60),
+                            RedirectUris = new()
+                            {
+                                "http://localhost:5100",
+                                "http://localhost:5100/connect/authorize/callback",
+                            },
+                            RedirectUrisPostLogout = new()
+                            {
+                                "http://localhost:5100",
+                                "http://localhost:5100/signout-callback-oidc",
+                            },
+                            Scopes = new() { "openid", "email", "phone", "profile", "role", "exampleapiscope" },
                         },
-                        RedirectUrisPostLogout = new()
-                        {
-                            "http://localhost:5100",
-                            "http://localhost:5100/signout-callback-oidc",
-                        },
-                        Scopes = new() { "openid", "email", "phone", "profile", "role", "exampleapiscope" },
-                    }
+                        null
+                    )
                 },
                 {
                     "razorexample",
-                    new OidcClient
-                    {
-                        AccessTokenExpiry = TimeSpan.FromMinutes(15),
-                        ClientId = "razorexample",
-                        GrantTypes = new() { GrantType.AuthorizationCode, GrantType.RefreshToken },
-                        IdentityTokenExpiry = TimeSpan.FromMinutes(60),
-                        RedirectUris = new()
+                    (
+                        new OidcClient
                         {
-                            "http://localhost:5101",
-                            "http://localhost:5101/connect/authorize/callback",
+                            AccessTokenExpiry = TimeSpan.FromMinutes(15),
+                            ClientId = "razorexample",
+                            GrantTypes = new() { GrantType.AuthorizationCode, GrantType.RefreshToken },
+                            IdentityTokenExpiry = TimeSpan.FromMinutes(60),
+                            RedirectUris = new()
+                            {
+                                "http://localhost:5101",
+                                "http://localhost:5101/connect/authorize/callback",
+                            },
+                            RedirectUrisPostLogout = new()
+                            {
+                                "http://localhost:5101",
+                                "http://localhost:5101/signout-callback-oidc",
+                            },
+                            Scopes = new()
+                            {
+                                "openid",
+                                "offline_access",
+                                "email",
+                                "phone",
+                                "profile",
+                                "role",
+                                "exampleapiscope",
+                                "exampleproviderapiscope",
+                            },
                         },
-                        RedirectUrisPostLogout = new()
-                        {
-                            "http://localhost:5101",
-                            "http://localhost:5101/signout-callback-oidc",
-                        },
-                        Scopes = new()
-                        {
-                            "openid",
-                            "offline_access",
-                            "email",
-                            "phone",
-                            "profile",
-                            "role",
-                            "exampleapiscope",
-                            "exampleproviderapiscope",
-                        },
-                    }
+                        null
+                    )
                 },
             };
 
@@ -110,14 +122,18 @@ namespace InHouseOidc.Example.Provider
         {
             if (this.clients.TryGetValue(clientId, out var client))
             {
-                return Task.FromResult<OidcClient?>(client);
+                return Task.FromResult<OidcClient?>(client.OidcClient);
             }
             return Task.FromResult<OidcClient?>(null);
         }
 
-        public Task<bool> IsCorrectClientSecret(string clientSecretHashed, string checkClientSecretRaw)
+        public Task<bool> IsCorrectClientSecret(string clientId, string checkClientSecretRaw)
         {
-            return Task.FromResult(clientSecretHashed == checkClientSecretRaw);
+            if (!this.clients.TryGetValue(clientId, out var client))
+            {
+                return Task.FromResult(false);
+            }
+            return Task.FromResult(client.ClientSecret == checkClientSecretRaw);
         }
 
         public Task<bool> IsKnownPostLogoutRedirectUri(string postLogoutRedirectUri)
@@ -125,8 +141,8 @@ namespace InHouseOidc.Example.Provider
             foreach (var client in this.clients.Values)
             {
                 if (
-                    client.RedirectUrisPostLogout != null
-                    && client.RedirectUrisPostLogout.Contains(postLogoutRedirectUri)
+                    client.OidcClient.RedirectUrisPostLogout != null
+                    && client.OidcClient.RedirectUrisPostLogout.Contains(postLogoutRedirectUri)
                 )
                 {
                     return Task.FromResult(true);

--- a/InHouseOidc.Provider.Test/Handler/TokenHandlerTest.cs
+++ b/InHouseOidc.Provider.Test/Handler/TokenHandlerTest.cs
@@ -639,13 +639,13 @@ namespace InHouseOidc.Provider.Test.Handler
             {
                 AccessTokenExpiry = TimeSpan.FromMinutes(15),
                 ClientId = this.clientId,
-                ClientSecret = this.clientSecret,
+                ClientSecretRequired = true,
                 GrantTypes = new() { GrantType.ClientCredentials },
                 Scopes = new() { this.scope1 },
             };
             this.mockClientStore.Setup(m => m.GetClient(this.clientId)).ReturnsAsync(oidcClient);
             this.mockClientStore
-                .Setup(m => m.IsCorrectClientSecret(this.clientSecret, this.clientSecret))
+                .Setup(m => m.IsCorrectClientSecret(this.clientId, this.clientSecret))
                 .ReturnsAsync(true);
             var issuer = $"{this.urlScheme}://{this.host}";
             var accessToken = "access.token";
@@ -770,7 +770,7 @@ namespace InHouseOidc.Provider.Test.Handler
             CredCliEx.None,
             CredPrmEx.NoSecret,
             ProviderConstant.InvalidClient,
-            "Token request missing client_secret form field"
+            "Token request missing client_secret"
         )]
         [DataRow(
             CredAutEx.None,
@@ -888,7 +888,7 @@ namespace InHouseOidc.Provider.Test.Handler
             {
                 AccessTokenExpiry = TimeSpan.FromMinutes(15),
                 ClientId = this.clientId,
-                ClientSecret = this.clientSecret,
+                ClientSecretRequired = true,
                 GrantTypes = credClientEx switch
                 {
                     CredCliEx.NoGrants => null,
@@ -907,7 +907,7 @@ namespace InHouseOidc.Provider.Test.Handler
                 case CredCliEx.BadSecret:
                     this.mockClientStore.Setup(m => m.GetClient(this.clientId)).ReturnsAsync(oidcClient);
                     this.mockClientStore
-                        .Setup(m => m.IsCorrectClientSecret(this.clientSecret, this.clientSecret))
+                        .Setup(m => m.IsCorrectClientSecret(this.clientId, this.clientSecret))
                         .ReturnsAsync(false);
                     break;
                 case CredCliEx.BadScope:
@@ -917,7 +917,7 @@ namespace InHouseOidc.Provider.Test.Handler
                 case CredCliEx.NoScopes:
                     this.mockClientStore.Setup(m => m.GetClient(this.clientId)).ReturnsAsync(oidcClient);
                     this.mockClientStore
-                        .Setup(m => m.IsCorrectClientSecret(this.clientSecret, this.clientSecret))
+                        .Setup(m => m.IsCorrectClientSecret(this.clientId, this.clientSecret))
                         .ReturnsAsync(true);
                     break;
             }

--- a/InHouseOidc.Provider/Handler/TokenHandler.cs
+++ b/InHouseOidc.Provider/Handler/TokenHandler.cs
@@ -713,13 +713,13 @@ namespace InHouseOidc.Provider.Handler
                     ErrorArgs = new[] { clientId },
                 };
             }
-            if (!string.IsNullOrEmpty(oidcClient.ClientSecret))
+            if (oidcClient.ClientSecretRequired ?? false)
             {
                 if (string.IsNullOrWhiteSpace(clientSecret))
                 {
-                    return new ClientValidation { ErrorMessage = "Token request missing client_secret form field" };
+                    return new ClientValidation { ErrorMessage = "Token request missing client_secret" };
                 }
-                var isValidSecret = await this.clientStore.IsCorrectClientSecret(oidcClient.ClientSecret, clientSecret);
+                var isValidSecret = await this.clientStore.IsCorrectClientSecret(clientId, clientSecret);
                 if (!isValidSecret)
                 {
                     return new ClientValidation { ErrorMessage = "Invalid client_secret" };

--- a/InHouseOidc.Provider/IClientStore.cs
+++ b/InHouseOidc.Provider/IClientStore.cs
@@ -19,10 +19,10 @@ namespace InHouseOidc.Provider
         /// <summary>
         /// Validate a passed check client secret is correct based on the current client secret.
         /// </summary>
-        /// <param name="clientSecretHashed">The client secret hashed.</param>
+        /// <param name="clientId">The client identifier.</param>
         /// <param name="checkClientSecretRaw">The raw (clear text) client secret on the token request that needs to be verified.</param>
         /// <returns>True for client secret is correct.</returns>
-        Task<bool> IsCorrectClientSecret(string clientSecretHashed, string checkClientSecretRaw);
+        Task<bool> IsCorrectClientSecret(string clientId, string checkClientSecretRaw);
 
         /// <summary>
         /// Validate a passed post logout redirect URI.<br />

--- a/InHouseOidc.Provider/OidcClient.cs
+++ b/InHouseOidc.Provider/OidcClient.cs
@@ -21,9 +21,9 @@ namespace InHouseOidc.Provider
         public string? ClientId { get; init; }
 
         /// <summary>
-        /// Gets secret for this client.  Should always be stored as a hashed value.
+        /// Indicates that a client secret must be supplied to authenticate this client.
         /// </summary>
-        public string? ClientSecret { get; init; }
+        public bool? ClientSecretRequired { get; init; }
 
         /// <summary>
         /// Gets the grant types this client supports. Required for all flows.


### PR DESCRIPTION
Replace OidcClient.ClientSecret with ClientSecretRequired.
Pass ClientId as parameter to IClientStore.IsCorrectClientSecret.
Fix cookie clash bug in Certify.Provider.

Closes #3 