### PR TITLE
Fix AddClientCredentialsToken cannot be used to directly setup an HttpClient

### DIFF
--- a/InHouseOidc.CredentialsClient.Test/AddClientCredentialsTokenExtensionTest.cs
+++ b/InHouseOidc.CredentialsClient.Test/AddClientCredentialsTokenExtensionTest.cs
@@ -22,7 +22,7 @@ namespace InHouseOidc.CredentialsClient.Test
             var clientCredentialsResolver = new Mock<IClientCredentialsResolver>();
             serviceCollection.AddSingleton(clientCredentialsResolver.Object);
             // Act
-            serviceCollection.AddHttpClient(clientName).AddClientCredentialsToken(clientName);
+            serviceCollection.AddHttpClient(clientName).AddClientCredentialsToken();
             var serviceProvider = serviceCollection.BuildServiceProvider();
             // Assert
             var httpClientFactory = serviceProvider.GetRequiredService<IHttpClientFactory>();

--- a/InHouseOidc.CredentialsClient.Test/CredentialsClientBuilderTest.cs
+++ b/InHouseOidc.CredentialsClient.Test/CredentialsClientBuilderTest.cs
@@ -24,7 +24,7 @@ namespace InHouseOidc.CredentialsClient.Test
         }
 
         [TestMethod]
-        public void ClientBuilder_AddClient_WithOptions()
+        public void ClientBuilder_AddClient()
         {
             // Arrange
             var clientName = "CredentialsClient";
@@ -37,36 +37,6 @@ namespace InHouseOidc.CredentialsClient.Test
             };
             // Act
             var clientBuilder = this.serviceCollection.AddOidcCredentialsClient().AddClient(clientName, clientOptions);
-            var duplicateException = Assert.ThrowsException<ArgumentException>(
-                () => clientBuilder.AddClient(clientName)
-            );
-            clientBuilder.Build();
-            var serviceProvider = this.serviceCollection.BuildServiceProvider();
-            // Assert
-            _ = serviceProvider.GetRequiredService<ClientOptions>();
-            _ = serviceProvider.GetRequiredService<IDiscoveryResolver>();
-            _ = serviceProvider.GetRequiredService<IClientCredentialsResolver>();
-            var httpClientFactory = serviceProvider.GetRequiredService<IHttpClientFactory>();
-            var httpClient = httpClientFactory.CreateClient(clientName);
-            Assert.IsNotNull(httpClient);
-            Assert.IsNotNull(duplicateException);
-            Assert.IsTrue(duplicateException.Message.Contains("Duplicate client name"));
-        }
-
-        [TestMethod]
-        public void ClientBuilder_AddClient_WithoutOptions()
-        {
-            // Arrange
-            var clientName = "CredentialsClient";
-            var clientOptions = new CredentialsClientOptions
-            {
-                ClientId = clientName,
-                ClientSecret = "TopSecret",
-                OidcProviderAddress = "https://localhost",
-                Scope = "scope1",
-            };
-            // Act
-            var clientBuilder = this.serviceCollection.AddOidcCredentialsClient().AddClient(clientName);
             var duplicateException = Assert.ThrowsException<ArgumentException>(
                 () => clientBuilder.AddClient(clientName, clientOptions)
             );

--- a/InHouseOidc.CredentialsClient.Test/Resolver/ClientCredentialsResolverTest.cs
+++ b/InHouseOidc.CredentialsClient.Test/Resolver/ClientCredentialsResolverTest.cs
@@ -164,9 +164,7 @@ namespace InHouseOidc.ClientCredentials.Test.Resolver
             }
             else
             {
-                this.mockServiceProvider
-                    .Setup(m => m.GetService(typeof(ICredentialsStore)))
-                    .Returns(null);
+                this.mockServiceProvider.Setup(m => m.GetService(typeof(ICredentialsStore))).Returns(null);
             }
             // Act
             var result = await clientCredentialsResolver.GetClientToken(clientName, CancellationToken.None);

--- a/InHouseOidc.CredentialsClient.Test/Resolver/ClientCredentialsResolverTest.cs
+++ b/InHouseOidc.CredentialsClient.Test/Resolver/ClientCredentialsResolverTest.cs
@@ -137,8 +137,10 @@ namespace InHouseOidc.ClientCredentials.Test.Resolver
             Assert.AreEqual("accesstoken", result4);
         }
 
-        [TestMethod]
-        public async Task ClientCredentialsResolver_BadClientName()
+        [DataTestMethod]
+        [DataRow(false, "Client credentials options not available via AddClient or ICredentialsStore")]
+        [DataRow(true, "Client credentials options not available from ICredentialsStore")]
+        public async Task ClientCredentialsResolver_BadClientName(bool setupCredentialsStore, string expectedMessage)
         {
             // Arrange
             var clientCredentialsResolver = new ClientCredentialsResolver(
@@ -149,11 +151,28 @@ namespace InHouseOidc.ClientCredentials.Test.Resolver
                 this.mockServiceProvider.Object,
                 this.mockUtcNow.Object
             );
+            var clientName = "badclientname";
+            if (setupCredentialsStore)
+            {
+                var mockCredentialsStore = new Mock<ICredentialsStore>(MockBehavior.Strict);
+                mockCredentialsStore
+                    .Setup(m => m.GetCredentialsClientOptions(clientName))
+                    .Returns(Task.FromResult<CredentialsClientOptions?>(null));
+                this.mockServiceProvider
+                    .Setup(m => m.GetService(typeof(ICredentialsStore)))
+                    .Returns(mockCredentialsStore.Object);
+            }
+            else
+            {
+                this.mockServiceProvider
+                    .Setup(m => m.GetService(typeof(ICredentialsStore)))
+                    .Returns(null);
+            }
             // Act
-            var result = await clientCredentialsResolver.GetClientToken("badclientname", CancellationToken.None);
+            var result = await clientCredentialsResolver.GetClientToken(clientName, CancellationToken.None);
             // Assert
             Assert.IsNull(result);
-            this.logger.AssertLastItemContains(LogLevel.Error, "Unable to resolve client credential options");
+            this.logger.AssertLastItemContains(LogLevel.Error, expectedMessage);
         }
 
         [TestMethod]

--- a/InHouseOidc.CredentialsClient/AddClientCredentialsTokenExtension.cs
+++ b/InHouseOidc.CredentialsClient/AddClientCredentialsTokenExtension.cs
@@ -15,9 +15,7 @@ namespace InHouseOidc.CredentialsClient
         /// </summary>
         /// <param name="httpClientBuilder">The HttpClientBuilder being configured during startup.</param>
         /// <returns>ProviderBuilder.</returns>
-        public static IHttpClientBuilder AddClientCredentialsToken(
-            this IHttpClientBuilder httpClientBuilder
-        )
+        public static IHttpClientBuilder AddClientCredentialsToken(this IHttpClientBuilder httpClientBuilder)
         {
             return httpClientBuilder.AddHttpMessageHandler(serviceProvider =>
             {

--- a/InHouseOidc.CredentialsClient/AddClientCredentialsTokenExtension.cs
+++ b/InHouseOidc.CredentialsClient/AddClientCredentialsTokenExtension.cs
@@ -14,17 +14,15 @@ namespace InHouseOidc.CredentialsClient
         /// A message handler is added to any built HttpClient that automatically includes an Authorization header in all requests.
         /// </summary>
         /// <param name="httpClientBuilder">The HttpClientBuilder being configured during startup.</param>
-        /// <param name="clientName">The named HttpClient requiring access tokens.</param>
         /// <returns>ProviderBuilder.</returns>
         public static IHttpClientBuilder AddClientCredentialsToken(
-            this IHttpClientBuilder httpClientBuilder,
-            string clientName
+            this IHttpClientBuilder httpClientBuilder
         )
         {
             return httpClientBuilder.AddHttpMessageHandler(serviceProvider =>
             {
                 var credentialsAccessTokenResolver = serviceProvider.GetRequiredService<IClientCredentialsResolver>();
-                return new ClientCredentialsHandler(credentialsAccessTokenResolver, clientName);
+                return new ClientCredentialsHandler(credentialsAccessTokenResolver, httpClientBuilder.Name);
             });
         }
     }

--- a/InHouseOidc.CredentialsClient/CredentialsClientBuilder.cs
+++ b/InHouseOidc.CredentialsClient/CredentialsClientBuilder.cs
@@ -39,22 +39,6 @@ namespace InHouseOidc.CredentialsClient
         }
 
         /// <summary>
-        /// Sets up a named HttpClient with client credentials token access.<br />
-        /// Client credentials options are retrieved after startup from the registered ICredentialsStore service.
-        /// </summary>
-        /// <param name="clientName">The HttpClient name to allocate.</param>
-        /// <returns><see cref="CredentialsClientBuilder"/> so additional calls can be chained.</returns>
-        public CredentialsClientBuilder AddClient(string clientName)
-        {
-            // Configure
-            if (!this.ClientOptions.CredentialsClientsOptions.TryAdd(clientName, null))
-            {
-                throw new ArgumentException($"Duplicate client name: {clientName}", nameof(clientName));
-            }
-            return this;
-        }
-
-        /// <summary>
         /// Builds the final services for the client. Required as the final step of the client setup.
         /// </summary>
         public void Build()
@@ -66,15 +50,15 @@ namespace InHouseOidc.CredentialsClient
             this.ServiceCollection.AddSingleton(this.ClientOptions);
             this.ServiceCollection.AddHttpClient(this.ClientOptions.InternalHttpClientName);
             this.ServiceCollection.TryAddSingleton<IDiscoveryResolver, DiscoveryResolver>();
+            this.ServiceCollection.TryAddSingleton<IClientCredentialsResolver, ClientCredentialsResolver>();
             // Setup the credentials clients added
             if (this.ClientOptions.CredentialsClientsOptions.Any())
             {
-                this.ServiceCollection.TryAddSingleton<IClientCredentialsResolver, ClientCredentialsResolver>();
                 var clientNames = this.ClientOptions.CredentialsClientsOptions.Keys;
                 foreach (var clientName in clientNames)
                 {
                     // Add the HTTP client and bind the token handler
-                    this.ServiceCollection.AddHttpClient(clientName).AddClientCredentialsToken(clientName);
+                    this.ServiceCollection.AddHttpClient(clientName).AddClientCredentialsToken();
                 }
             }
         }

--- a/InHouseOidc.CredentialsClient/ICredentialsStore.cs
+++ b/InHouseOidc.CredentialsClient/ICredentialsStore.cs
@@ -13,8 +13,9 @@ namespace InHouseOidc.CredentialsClient
         /// <summary>
         /// Get client credentials options for a client name.
         /// </summary>
-        /// <param name="clientName">The client name registed at startup using <see cref="ClientBuilder.AddClient(string)"></see>.</param>
+        /// <param name="clientName">The client name registed at startup using <see cref="ClientBuilder.AddClient(string)"></see>,
+        /// or resolvable at runtime via the implementation of ICredentialsStore.</param>
         /// <returns><see cref="CredentialsClientOptions"/>.</returns>
-        Task<CredentialsClientOptions> GetCredentialsClientOptions(string clientName);
+        Task<CredentialsClientOptions?> GetCredentialsClientOptions(string clientName);
     }
 }

--- a/InHouseOidc.CredentialsClient/Resolver/ClientCredentialsResolver.cs
+++ b/InHouseOidc.CredentialsClient/Resolver/ClientCredentialsResolver.cs
@@ -63,16 +63,22 @@ namespace InHouseOidc.CredentialsClient.Resolver
                 this.tokenDictionary.TryRemove(clientName, out var _);
             }
             // Lookup the client credentials options
-            if (!this.clientOptions.CredentialsClientsOptions.TryGetValue(clientName, out var clientCredentialsOptions))
-            {
-                this.logger.LogError("Unable to resolve client credential options");
-                return null;
-            }
+            this.clientOptions.CredentialsClientsOptions.TryGetValue(clientName, out var clientCredentialsOptions);
             if (clientCredentialsOptions == null)
             {
                 // Retrieve the options and save the value for all subsequent token requests
-                var credentialsStore = this.serviceProvider.GetRequiredService<ICredentialsStore>();
+                var credentialsStore = this.serviceProvider.GetService<ICredentialsStore>();
+                if (credentialsStore == null)
+                {
+                    this.logger.LogError("Client credentials options not available via AddClient or ICredentialsStore");
+                    return null;
+                }
                 clientCredentialsOptions = await credentialsStore.GetCredentialsClientOptions(clientName);
+                if (clientCredentialsOptions == null)
+                {
+                    this.logger.LogError("Client credentials options not available from ICredentialsStore");
+                    return null;
+                }
                 this.clientOptions.CredentialsClientsOptions[clientName] = clientCredentialsOptions;
             }
             // Confirm required client options fields are present

--- a/InHouseOidc.Example.CredentialsClient/CredentialsStore.cs
+++ b/InHouseOidc.Example.CredentialsClient/CredentialsStore.cs
@@ -1,0 +1,29 @@
+﻿// Copyright 2022 Brent Johnson.
+// Licensed under the Apache License, Version 2.0 (refer to the LICENSE file in the solution folder).
+
+using InHouseOidc.CredentialsClient;
+
+namespace InHouseOidc.Example.CredentialsClient
+{
+    internal class CredentialsStore : ICredentialsStore
+    {
+        public Task<CredentialsClientOptions?> GetCredentialsClientOptions(string clientName)
+        {
+            if (clientName != "exampleapiruntime")
+            {
+                return Task.FromResult<CredentialsClientOptions?>(null);
+            }
+            const string providerAddress = "http://localhost:5100";
+            const string clientId = "clientcredentialsexample";
+            const string clientSecret = "topsecret";
+            const string scope = "exampleapiscope";
+            return Task.FromResult<CredentialsClientOptions?>(new CredentialsClientOptions
+            {
+                ClientId = clientId,
+                ClientSecret = clientSecret,
+                Scope = scope,
+                OidcProviderAddress = providerAddress,
+            });
+        }
+    }
+}

--- a/InHouseOidc.Example.CredentialsClient/CredentialsStore.cs
+++ b/InHouseOidc.Example.CredentialsClient/CredentialsStore.cs
@@ -17,13 +17,15 @@ namespace InHouseOidc.Example.CredentialsClient
             const string clientId = "clientcredentialsexample";
             const string clientSecret = "topsecret";
             const string scope = "exampleapiscope";
-            return Task.FromResult<CredentialsClientOptions?>(new CredentialsClientOptions
-            {
-                ClientId = clientId,
-                ClientSecret = clientSecret,
-                Scope = scope,
-                OidcProviderAddress = providerAddress,
-            });
+            return Task.FromResult<CredentialsClientOptions?>(
+                new CredentialsClientOptions
+                {
+                    ClientId = clientId,
+                    ClientSecret = clientSecret,
+                    Scope = scope,
+                    OidcProviderAddress = providerAddress,
+                }
+            );
         }
     }
 }

--- a/InHouseOidc.Example.CredentialsClient/Program.cs
+++ b/InHouseOidc.Example.CredentialsClient/Program.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0 (refer to the LICENSE file in the solution folder).
 
 using InHouseOidc.CredentialsClient;
+using InHouseOidc.Example.CredentialsClient;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -14,15 +15,20 @@ serviceCollection.AddLogging(
 );
 
 // Setup the OIDC client
+const string clientNameStartup = "exampleapistartup";
+const string clientNameRuntime = "exampleapiruntime";
 const string providerAddress = "http://localhost:5100";
-const string clientName = "exampleapi";
 const string clientId = "clientcredentialsexample";
 const string clientSecret = "topsecret";
 const string scope = "exampleapiscope";
 serviceCollection
+    .AddSingleton<ICredentialsStore, CredentialsStore>()
+    .AddHttpClient(clientNameRuntime)
+        .AddClientCredentialsToken();
+serviceCollection
     .AddOidcCredentialsClient()
     .AddClient(
-        clientName,
+        clientNameStartup,
         new CredentialsClientOptions
         {
             ClientId = clientId,
@@ -49,11 +55,16 @@ while (true)
     try
     {
         var httpClientFactory = serviceProvider.GetRequiredService<IHttpClientFactory>();
-        var httpClient = httpClientFactory.CreateClient(clientName);
-        var response = await httpClient.GetAsync(new Uri(new Uri(apiAddress), "/secure"));
-        response.EnsureSuccessStatusCode();
-        var responseContent = await response.Content.ReadAsStringAsync();
-        logger.LogInformation("/secure response: {responseContent}", responseContent);
+        var httpClientStartup = httpClientFactory.CreateClient(clientNameStartup);
+        var responseStartup = await httpClientStartup.GetAsync(new Uri(new Uri(apiAddress), "/secure"));
+        responseStartup.EnsureSuccessStatusCode();
+        var responseContentStartup = await responseStartup.Content.ReadAsStringAsync();
+        logger.LogInformation("[Startup HttpClient] /secure response: {responseContent}", responseContentStartup);
+        var httpClientRuntime = httpClientFactory.CreateClient(clientNameRuntime);
+        var responseRuntime = await httpClientRuntime.GetAsync(new Uri(new Uri(apiAddress), "/secure"));
+        responseRuntime.EnsureSuccessStatusCode();
+        var responseContentRuntime = await responseRuntime.Content.ReadAsStringAsync();
+        logger.LogInformation("[Runtime HttpClient] /secure response: {responseContent}", responseContentRuntime);
     }
     catch (Exception ex)
     {

--- a/InHouseOidc.Example.CredentialsClient/Program.cs
+++ b/InHouseOidc.Example.CredentialsClient/Program.cs
@@ -24,7 +24,7 @@ const string scope = "exampleapiscope";
 serviceCollection
     .AddSingleton<ICredentialsStore, CredentialsStore>()
     .AddHttpClient(clientNameRuntime)
-        .AddClientCredentialsToken();
+    .AddClientCredentialsToken();
 serviceCollection
     .AddOidcCredentialsClient()
     .AddClient(


### PR DESCRIPTION
Add testing of runtime and startup clients to client credentials example.
Log errors for client not found via AddClient or ICredentialsStore.
Don't pass clientName as parameter with AddClientCredentialsToken.
Support runtime only clients (via ICredentialsStore).
Allow returning null from ICredentialsStore.GetCredentialsClientOptions.

Closes #5 