### PR TITLE
Fix issues 32 and 33

### DIFF
--- a/InHouseOidc.Certify.Provider/ClientStore.cs
+++ b/InHouseOidc.Certify.Provider/ClientStore.cs
@@ -28,7 +28,6 @@ namespace InHouseOidc.Certify.Provider
                                 clientConfig?.GrantTypes == null
                                     ? []
                                     : clientConfig.GrantTypes.Select(EnumHelper.ParseEnumMember<GrantType>).ToList(),
-                            IdentityTokenExpiry = TimeSpan.FromMinutes(clientConfig?.IdentityTokenExpiryMinutes ?? 0),
                             RedirectUris = clientConfig?.RedirectUris,
                             RedirectUrisPostLogout = clientConfig?.RedirectUrisPostLogout,
                             Scopes = clientConfig?.Scopes,

--- a/InHouseOidc.Example.Common/ExampleHelper.cs
+++ b/InHouseOidc.Example.Common/ExampleHelper.cs
@@ -28,7 +28,7 @@ namespace InHouseOidc.Example.Common
             );
             var accessTokenExpiry = await httpContext.GetTokenAsync(
                 OpenIdConnectDefaults.AuthenticationScheme,
-                "ExpiresAt"
+                PageConstant.ExpiresAt
             );
             var claims = new List<Claim>();
             var name = string.Empty;

--- a/InHouseOidc.Example.Provider/ClientStore.cs
+++ b/InHouseOidc.Example.Provider/ClientStore.cs
@@ -19,7 +19,6 @@ namespace InHouseOidc.Example.Provider
                             ClientId = "bffexample",
                             ClientSecretRequired = true,
                             GrantTypes = [GrantType.AuthorizationCode, GrantType.RefreshToken],
-                            IdentityTokenExpiry = TimeSpan.FromMinutes(60),
                             RedirectUris = ["http://localhost:5105", "http://localhost:5105/api/auth/callback",],
                             RedirectUrisPostLogout =
                             [
@@ -34,7 +33,7 @@ namespace InHouseOidc.Example.Provider
                                 "phone",
                                 "profile",
                                 "role",
-                                "examplebffscope",
+                                "exampleapiscope",
                                 "exampleproviderapiscope",
                             ],
                         },
@@ -64,7 +63,6 @@ namespace InHouseOidc.Example.Provider
                             ClientId = "mvcexample",
                             ClientSecretRequired = true,
                             GrantTypes = [GrantType.AuthorizationCode, GrantType.RefreshToken],
-                            IdentityTokenExpiry = TimeSpan.FromMinutes(60),
                             RedirectUris =
                             [
                                 "http://localhost:5103",
@@ -98,8 +96,7 @@ namespace InHouseOidc.Example.Provider
                             AccessTokenExpiry = TimeSpan.FromMinutes(15),
                             ClientId = "providerexample",
                             ClientSecretRequired = true,
-                            GrantTypes = [GrantType.AuthorizationCode],
-                            IdentityTokenExpiry = TimeSpan.FromMinutes(60),
+                            GrantTypes = [GrantType.AuthorizationCode, GrantType.RefreshToken],
                             RedirectUris =
                             [
                                 "http://localhost:5100",
@@ -110,7 +107,16 @@ namespace InHouseOidc.Example.Provider
                                 "http://localhost:5100",
                                 "http://localhost:5100/signout-callback-oidc",
                             ],
-                            Scopes = ["openid", "email", "phone", "profile", "role", "exampleapiscope"],
+                            Scopes =
+                            [
+                                "openid",
+                                "offline_access",
+                                "email",
+                                "phone",
+                                "profile",
+                                "role",
+                                "exampleapiscope"
+                            ],
                         },
                         "topsecret"
                     )
@@ -124,7 +130,6 @@ namespace InHouseOidc.Example.Provider
                             ClientId = "razorexample",
                             ClientSecretRequired = true,
                             GrantTypes = [GrantType.AuthorizationCode, GrantType.RefreshToken],
-                            IdentityTokenExpiry = TimeSpan.FromMinutes(60),
                             RedirectUris =
                             [
                                 "http://localhost:5101",

--- a/InHouseOidc.Example.Provider/Pages/Index.cshtml
+++ b/InHouseOidc.Example.Provider/Pages/Index.cshtml
@@ -2,7 +2,7 @@
 @using InHouseOidc.Example.Provider
 @namespace InHouseOidc.Example.Provider.Pages
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
-@model Provider.Index
+@model Index
 @{
     Layout = "_Layout";
     ViewData["Title"] = "Home";

--- a/InHouseOidc.Example.Provider/Pages/Index.cshtml.cs
+++ b/InHouseOidc.Example.Provider/Pages/Index.cshtml.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
-namespace InHouseOidc.Example.Provider
+namespace InHouseOidc.Example.Provider.Pages
 {
     [Authorize(AuthenticationSchemes = OpenIdConnectDefaults.AuthenticationScheme, Roles = "UserRole1,UserRole2")]
     public class Index(IHttpClientFactory httpClientFactory) : PageModel

--- a/InHouseOidc.Example.Provider/Pages/Login.cshtml.cs
+++ b/InHouseOidc.Example.Provider/Pages/Login.cshtml.cs
@@ -6,7 +6,7 @@ using InHouseOidc.Provider;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
-namespace InHouseOidc.Example.Provider
+namespace InHouseOidc.Example.Provider.Pages
 {
     public class Login(IProviderSession providerSession) : PageModel
     {

--- a/InHouseOidc.Example.Provider/Program.cs
+++ b/InHouseOidc.Example.Provider/Program.cs
@@ -52,7 +52,7 @@ var clientOptions = new PageClientOptions
     // GetClaimsFromUserInfoEndpoint = true,
     IssueLocalAuthenticationCookie = false,
     OidcProviderAddress = providerAddress,
-    Scope = "openid email phone profile role exampleapiscope",
+    Scope = "openid offline_access email phone profile role exampleapiscope",
     UniqueClaimMappings = new() { { "phone_number", "phone_number" } },
 };
 const string clientName = "exampleapi";

--- a/InHouseOidc.Example.Razor/Pages/Index.cshtml
+++ b/InHouseOidc.Example.Razor/Pages/Index.cshtml
@@ -1,7 +1,8 @@
 ﻿@page
 @using InHouseOidc.Example.Razor
+@namespace InHouseOidc.Example.Razor.Pages
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
-@model             InHouseOidc.Example.Razor.Index
+@model Index
 @{
     Layout = "_Layout";
     ViewData["Title"] = "Home";

--- a/InHouseOidc.Example.Razor/Pages/Index.cshtml.cs
+++ b/InHouseOidc.Example.Razor/Pages/Index.cshtml.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
-namespace InHouseOidc.Example.Razor
+namespace InHouseOidc.Example.Razor.Pages
 {
     [Authorize(Roles = "UserRole1,UserRole2")]
     public class Index(IHttpClientFactory httpClientFactory) : PageModel

--- a/InHouseOidc.Example.React/src/App.tsx
+++ b/InHouseOidc.Example.React/src/App.tsx
@@ -14,6 +14,7 @@ function App() {
     sessionState,
   } = useAuthentication();
   const [apiResult, setApiResult] = useState("");
+  const [bffResult, setBffResult] = useState("");
   const [providerApiResult, setProviderApiResult] = useState("");
   const callApi = useCallback(
     async (url: string, setResult: (result: string) => void) => {
@@ -65,7 +66,13 @@ function App() {
               </tbody>
             </table>
             <div className="d-flex mt-2 align-items-center">
-              <button onClick={() => callApi("/api/secure", setApiResult)}>
+              <button onClick={() => callApi("/api/secure-bff", setBffResult)}>
+                Call BFF
+              </button>
+              <span className="ml-2">{bffResult}</span>
+            </div>
+            <div className="d-flex mt-2 align-items-center">
+              <button onClick={() => callApi("/api/secure-api", setApiResult)}>
                 Call API
               </button>
               <span className="ml-2">{apiResult}</span>

--- a/InHouseOidc.Example.React/src/AuthenticationProvider.tsx
+++ b/InHouseOidc.Example.React/src/AuthenticationProvider.tsx
@@ -59,7 +59,7 @@ export const AuthenticationProvider = ({
       userInfo.clientId &&
       userInfo.sessionState
     ) {
-      const { clientId, checkSessionUri, sessionState } = userInfo;
+      const { clientId, checkSessionUri, sessionExpiry, sessionState } = userInfo;
       const createIFrame = async () => {
         // Setup the iframe to monitor the current session
         checkSessionIFrameRef.current = new CheckSessionIFrame(
@@ -68,7 +68,7 @@ export const AuthenticationProvider = ({
           checkSessionUri
         );
         await checkSessionIFrameRef.current.setup();
-        checkSessionIFrameRef.current.start(sessionState);
+        checkSessionIFrameRef.current.start(sessionExpiry, sessionState);
       };
       createIFrame();
     }

--- a/InHouseOidc.Example.React/src/CheckSessionIFrame.ts
+++ b/InHouseOidc.Example.React/src/CheckSessionIFrame.ts
@@ -2,6 +2,7 @@ export class CheckSessionIFrame {
   private iFrameOrigin: string;
   private iFrame: HTMLIFrameElement;
   private timeout: ReturnType<typeof setInterval> | null = null;
+  private sessionExpiry?: Date;
   private sessionState: string | null = null;
 
   public constructor(
@@ -32,13 +33,19 @@ export class CheckSessionIFrame {
     });
   }
 
-  public start(sessionState: string) {
+  public start(sessionExpiry: Date | undefined, sessionState: string) {
+    this.sessionExpiry = sessionExpiry ? new Date(sessionExpiry) : undefined;
     if (this.sessionState === sessionState) {
       return;
     }
     this.stop();
     this.sessionState = sessionState;
     const send = () => {
+      if (this.sessionExpiry && new Date() >= this.sessionExpiry) {
+        this.stop();
+        this.callback();
+        return;
+      }
       if (!this.iFrame.contentWindow) {
         return;
       }

--- a/InHouseOidc.Provider.Test/Extension/HttpRequestExtensionTest.cs
+++ b/InHouseOidc.Provider.Test/Extension/HttpRequestExtensionTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0 (refer to the LICENSE file in the solution folder).
 
 using InHouseOidc.Common.Constant;
+using InHouseOidc.Provider.Constant;
 using InHouseOidc.Provider.Extension;
 using InHouseOidc.Test.Common;
 using Microsoft.AspNetCore.Authentication;

--- a/InHouseOidc.Provider.Test/Handler/AuthorizationHandlerTest.cs
+++ b/InHouseOidc.Provider.Test/Handler/AuthorizationHandlerTest.cs
@@ -3,6 +3,7 @@
 
 using InHouseOidc.Common;
 using InHouseOidc.Common.Constant;
+using InHouseOidc.Provider.Constant;
 using InHouseOidc.Provider.Exception;
 using InHouseOidc.Provider.Handler;
 using InHouseOidc.Provider.Type;

--- a/InHouseOidc.Provider.Test/Handler/EndSessionHandlerTest.cs
+++ b/InHouseOidc.Provider.Test/Handler/EndSessionHandlerTest.cs
@@ -3,6 +3,7 @@
 
 using InHouseOidc.Common;
 using InHouseOidc.Common.Constant;
+using InHouseOidc.Provider.Constant;
 using InHouseOidc.Provider.Exception;
 using InHouseOidc.Provider.Handler;
 using InHouseOidc.Provider.Type;

--- a/InHouseOidc.Provider.Test/Handler/ProviderSessionHandlerTest.cs
+++ b/InHouseOidc.Provider.Test/Handler/ProviderSessionHandlerTest.cs
@@ -3,6 +3,7 @@
 
 using InHouseOidc.Common;
 using InHouseOidc.Common.Constant;
+using InHouseOidc.Provider.Constant;
 using InHouseOidc.Provider.Handler;
 using InHouseOidc.Provider.Type;
 using Microsoft.AspNetCore.Authentication;

--- a/InHouseOidc.Provider.Test/Handler/TokenHandlerTest.cs
+++ b/InHouseOidc.Provider.Test/Handler/TokenHandlerTest.cs
@@ -4,6 +4,7 @@
 using InHouseOidc.Common;
 using InHouseOidc.Common.Constant;
 using InHouseOidc.Common.Type;
+using InHouseOidc.Provider.Constant;
 using InHouseOidc.Provider.Exception;
 using InHouseOidc.Provider.Handler;
 using InHouseOidc.Provider.Type;
@@ -155,7 +156,6 @@ namespace InHouseOidc.Provider.Test.Handler
                 AccessTokenExpiry = TimeSpan.FromMinutes(15),
                 ClientId = this.clientId,
                 GrantTypes = [GrantType.AuthorizationCode],
-                IdentityTokenExpiry = TimeSpan.FromMinutes(60),
             };
             this.mockClientStore.Setup(m => m.GetClient(this.clientId)).ReturnsAsync(oidcClient);
             var issuer = $"{this.urlScheme}://{this.host}";
@@ -543,7 +543,6 @@ namespace InHouseOidc.Provider.Test.Handler
                     AuthCliEx.ValidNoGrants => [],
                     _ => [GrantType.AuthorizationCode]
                 },
-                IdentityTokenExpiry = TimeSpan.FromMinutes(60),
             };
             switch (authClientEx)
             {

--- a/InHouseOidc.Provider.Test/Handler/UserInfoHandlerTest.cs
+++ b/InHouseOidc.Provider.Test/Handler/UserInfoHandlerTest.cs
@@ -3,6 +3,7 @@
 
 using InHouseOidc.Common;
 using InHouseOidc.Common.Constant;
+using InHouseOidc.Provider.Constant;
 using InHouseOidc.Provider.Exception;
 using InHouseOidc.Provider.Handler;
 using Microsoft.AspNetCore.Http;

--- a/InHouseOidc.Provider.Test/Handler/ValidationHandlerTest.cs
+++ b/InHouseOidc.Provider.Test/Handler/ValidationHandlerTest.cs
@@ -3,6 +3,7 @@
 
 using InHouseOidc.Common;
 using InHouseOidc.Common.Constant;
+using InHouseOidc.Provider.Constant;
 using InHouseOidc.Provider.Extension;
 using InHouseOidc.Provider.Handler;
 using InHouseOidc.Provider.Type;
@@ -71,7 +72,6 @@ namespace InHouseOidc.Provider.Test.Handler
                 AccessTokenExpiry = TimeSpan.FromMinutes(15),
                 ClientId = this.clientId,
                 GrantTypes = [GrantType.AuthorizationCode],
-                IdentityTokenExpiry = TimeSpan.FromMinutes(60),
                 RedirectUris = [this.redirectUri],
                 Scopes = ["openid", this.scope1],
             };
@@ -291,7 +291,6 @@ namespace InHouseOidc.Provider.Test.Handler
                     ValCliEx.GrantsNull => null,
                     _ => [GrantType.AuthorizationCode]
                 },
-                IdentityTokenExpiry = TimeSpan.FromMinutes(60),
                 RedirectUris = valCliEx switch
                 {
                     ValCliEx.RedirectUriBad => [],
@@ -418,7 +417,7 @@ namespace InHouseOidc.Provider.Test.Handler
                 case ValReqEx.StateLength:
                     parameters.Add(AuthorizationEndpointConstant.ClientId, this.clientId);
                     parameters.Add(AuthorizationEndpointConstant.RedirectUri, this.redirectUri);
-                    parameters.Add(AuthorizationEndpointConstant.State, new string('z', 513));
+                    parameters.Add(AuthorizationEndpointConstant.State, new string('z', 1025));
                     break;
             }
             switch (valCliEx)

--- a/InHouseOidc.Provider.Test/ProviderBuilderTest.cs
+++ b/InHouseOidc.Provider.Test/ProviderBuilderTest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright 2022 Brent Johnson.
 // Licensed under the Apache License, Version 2.0 (refer to the LICENSE file in the solution folder).
 
+using InHouseOidc.Provider.Constant;
 using InHouseOidc.Provider.Handler;
 using InHouseOidc.Provider.Type;
 using InHouseOidc.Test.Common;

--- a/InHouseOidc.Provider/Constant/ProviderConstant.cs
+++ b/InHouseOidc.Provider/Constant/ProviderConstant.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright 2022 Brent Johnson.
 // Licensed under the Apache License, Version 2.0 (refer to the LICENSE file in the solution folder).
 
-namespace InHouseOidc.Provider
+namespace InHouseOidc.Provider.Constant
 {
     internal static class ProviderConstant
     {

--- a/InHouseOidc.Provider/Extension/HttpRequestExtension.cs
+++ b/InHouseOidc.Provider/Extension/HttpRequestExtension.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0 (refer to the LICENSE file in the solution folder).
 
 using InHouseOidc.Common.Constant;
+using InHouseOidc.Provider.Constant;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;

--- a/InHouseOidc.Provider/Handler/DiscoveryHandler.cs
+++ b/InHouseOidc.Provider/Handler/DiscoveryHandler.cs
@@ -3,6 +3,7 @@
 
 using InHouseOidc.Common;
 using InHouseOidc.Common.Constant;
+using InHouseOidc.Provider.Constant;
 using InHouseOidc.Provider.Exception;
 using InHouseOidc.Provider.Extension;
 using InHouseOidc.Provider.Type;

--- a/InHouseOidc.Provider/Handler/ProviderSessionHandler.cs
+++ b/InHouseOidc.Provider/Handler/ProviderSessionHandler.cs
@@ -3,6 +3,7 @@
 
 using InHouseOidc.Common;
 using InHouseOidc.Common.Constant;
+using InHouseOidc.Provider.Constant;
 using InHouseOidc.Provider.Extension;
 using InHouseOidc.Provider.Type;
 using Microsoft.AspNetCore.Authentication;

--- a/InHouseOidc.Provider/Handler/TokenHandler.cs
+++ b/InHouseOidc.Provider/Handler/TokenHandler.cs
@@ -3,6 +3,7 @@
 
 using InHouseOidc.Common;
 using InHouseOidc.Common.Constant;
+using InHouseOidc.Provider.Constant;
 using InHouseOidc.Provider.Exception;
 using InHouseOidc.Provider.Extension;
 using InHouseOidc.Provider.Type;
@@ -690,11 +691,7 @@ namespace InHouseOidc.Provider.Handler
             var oidcClient = await this.clientStore.GetClient(clientId);
             if (oidcClient == null)
             {
-                return new ClientValidation
-                {
-                    ErrorMessage = "Unknown client id: {clientId}",
-                    ErrorArgs = new[] { clientId },
-                };
+                return new ClientValidation { ErrorMessage = "Unknown client id: {clientId}", ErrorArgs = [clientId], };
             }
             if (oidcClient.ClientSecretRequired ?? false)
             {

--- a/InHouseOidc.Provider/Handler/ValidationHandler.cs
+++ b/InHouseOidc.Provider/Handler/ValidationHandler.cs
@@ -69,7 +69,7 @@ namespace InHouseOidc.Provider.Handler
             // Capture any state to pass back on errors
             if (parameters.TryGetNonEmptyValue(AuthorizationEndpointConstant.State, out var state))
             {
-                if (state.Length > 512)
+                if (state.Length > 1024)
                 {
                     return ErrorAuthorization(
                         redirectUri,

--- a/InHouseOidc.Provider/OidcClient.cs
+++ b/InHouseOidc.Provider/OidcClient.cs
@@ -30,8 +30,11 @@ namespace InHouseOidc.Provider
 
         /// <summary>
         /// Gets the expiry time for identity tokens issued.
+        /// DEPRECATED: id token expiry is sourced from session expiry.
         /// </summary>
-        public TimeSpan IdentityTokenExpiry { get; init; }
+        [Obsolete("id token expiry is sourced from session expiry (via IProviderSession.Login)")]
+        [ExcludeFromCodeCoverage(Justification = "Obsolete")]
+        public TimeSpan? IdentityTokenExpiry { get; init; }
 
         /// <summary>
         /// Gets the allowed post logout redirect URIs.  Required for the authorisation code flow.

--- a/InHouseOidc.Provider/ProviderBuilder.cs
+++ b/InHouseOidc.Provider/ProviderBuilder.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright 2022 Brent Johnson.
 // Licensed under the Apache License, Version 2.0 (refer to the LICENSE file in the solution folder).
 
+using InHouseOidc.Provider.Constant;
 using InHouseOidc.Provider.Extension;
 using InHouseOidc.Provider.Handler;
 using InHouseOidc.Provider.Type;

--- a/InHouseOidc.Provider/Type/ProviderOptions.cs
+++ b/InHouseOidc.Provider/Type/ProviderOptions.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0 (refer to the LICENSE file in the solution folder).
 
 using InHouseOidc.Common.Constant;
+using InHouseOidc.Provider.Constant;
 
 namespace InHouseOidc.Provider.Type
 {

--- a/InHouseOidc.Provider/Type/RedirectError.cs
+++ b/InHouseOidc.Provider/Type/RedirectError.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright 2022 Brent Johnson.
 // Licensed under the Apache License, Version 2.0 (refer to the LICENSE file in the solution folder).
 
+using InHouseOidc.Provider.Constant;
+
 namespace InHouseOidc.Provider.Type
 {
     internal enum RedirectErrorType


### PR DESCRIPTION
Closes #32 
Closes #33
Add auto logout on session expiry to BFF example (issue 32)
Extend authcode state query param max allowed size (issue 33) Add remote API endpoint test to BFF example
Fix display of example access token expiry
Deprecate unused OidcClient.IdentityTokenExpiry
Fix various namespace vs folder mismatches
Fix provider example refresh token renewal